### PR TITLE
FIFO type added

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ cd ../../examples/apps/hello_ncs_cpp/ && make run
 
 # Example Go program
 
+The example below shows how to created and destroy the basic types the NCSDK API 2.0 provides
+
 ```go
 package main
 
@@ -37,53 +39,52 @@ import (
 	"github.com/milosgajdos83/ncs"
 )
 
-func main() {
-	fmt.Println("Creating NCS device handle")
-	dev, err := ncs.NewDevice(0)
+func ExitOnErr(err error) {
 	if err != nil {
 		fmt.Println("Error:", err)
 		os.Exit(1)
 	}
+}
+
+func main() {
+	fmt.Println("Creating NCS device handle")
+	dev, err := ncs.NewDevice(0)
+	ExitOnErr(err)
 	fmt.Println("NCS device handle created")
 
 	fmt.Println("Opening NCS device")
 	err = dev.Open()
-	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
-	}
+	ExitOnErr(err)
 	fmt.Println("NCS device opened")
 
 	fmt.Println("Creating NCS graph handle")
 	graph, err := ncs.NewGraph("TestGraph")
-	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
-	}
+	ExitOnErr(err)
 	fmt.Println("NCS graph created")
+
+	fmt.Println("Creating NCS FIFO handle")
+	fifo, err := ncs.NewFifo("TestFIFO", ncs.FifoHostRO)
+	ExitOnErr(err)
+	fmt.Println("NCS FIFO handle created")
+
+	fmt.Println("Destroying NCS FIFO")
+	err = fifo.Destroy()
+	ExitOnErr(err)
+	fmt.Println("NCS FIFO destroyed")
 
 	fmt.Println("Destroyig NCS graph")
 	err = graph.Destroy()
-	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
-	}
+	ExitOnErr(err)
 	fmt.Println("NCS graph destroyed")
 
 	fmt.Println("Closing NCS device")
 	err = dev.Close()
-	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
-	}
+	ExitOnErr(err)
 	fmt.Println("NCS device closed")
 
 	fmt.Println("Destroyig NCS device")
 	err = dev.Destroy()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	ExitOnErr(err)
 	fmt.Println("NCS device destroyed")
 }
 ```
@@ -97,6 +98,10 @@ Opening NCS device
 NCS device opened
 Creating NCS graph handle
 NCS graph created
+Creating NCS FIFO handle
+NCS FIFO handle created
+Destroying NCS FIFO
+NCS FIFO destroyed
 Destroyig NCS graph
 NCS graph destroyed
 Closing NCS device

--- a/ncs.cpp
+++ b/ncs.cpp
@@ -30,3 +30,13 @@ int ncs_GraphDestroy(void** graphHandle) {
         ncStatus_t s = ncGraphDestroy((struct ncGraphHandle_t**) graphHandle);
         return int(s);
 }
+
+int ncs_FifoCreate(const char* name, ncFifoType_t type, void** fifoHandle) {
+        ncStatus_t s = ncFifoCreate(name, type, (struct ncFifoHandle_t**) fifoHandle);
+        return int(s);
+}
+
+int ncs_FifoDestroy(void** fifoHandle) {
+        ncStatus_t s = ncFifoDestroy((struct ncFifoHandle_t**) fifoHandle);
+        return int(s);
+}

--- a/ncs.h
+++ b/ncs.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+typedef ncFifoType_t ncFifoType;
+typedef ncFifoDataType_t ncFifoDataType;
+
 int ncs_DeviceCreate(int idx, void **deviceHandle);
 int ncs_DeviceOpen(void* deviceHandle);
 int ncs_DeviceClose(void* deviceHandle);
@@ -15,6 +18,9 @@ int ncs_DeviceDestroy(void **deviceHandle);
 
 int ncs_GraphCreate(const char* name, void **graphHandle);
 int ncs_GraphDestroy(void **graphHandle);
+
+int ncs_FifoCreate(const char* name, ncFifoType_t type, void** fifoHandle);
+int ncs_FifoDestroy(void** fifoHandle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds NCS Fifo queue type and functions to create and destroy it.

This PR basically wraps up the create and destroy function for the most basic primitives the NCSDK 2.0 provides.

Now we should be able to move on to more complicated stuff \o/